### PR TITLE
release 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+### v0.1.3 (2024-11-21)
+* fixes app crash (#9).
+
 ### v0.1.2 (2024-11-18)
 * adds support for system theme (night mode), high contrast themes, and "text size" settings.
 * fixes bug where app icon is not displayed (#5).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 ### v0.1.3 (2024-11-21)
-* fixes app crash (#9).
+* fixes app crash in release apk caused by proguard-rules (#9).
 
 ### v0.1.2 (2024-11-18)
 * adds support for system theme (night mode), high contrast themes, and "text size" settings.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.forrestguice.suntimes.intervalmidpoints"
         minSdkVersion 14
         targetSdkVersion 33
-        versionCode 3
-        versionName "0.1.2"
+        versionCode 4
+        versionName "0.1.3"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,1 @@
+- fixes app crash (#9).

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,1 +1,10 @@
-- fixes app crash (#9).
+v0.1.3
+- fixes app crash in release apk (#9).
+
+v0.1.2
+- adds support for system theme (night mode), high contrast themes, and "text size" settings.
+- fixes bug where app icon is not displayed (#5).
+- fixes bug where battery optimization message is displayed repeatedly (#6).
+- fixes crash when Suntimes is not installed (#7).
+- fixes ANR when Suntimes ContentProvider fails to respond.
+- updates targetSdkVersion (30 -> 33), and migrates app to AndroidX.


### PR DESCRIPTION
*  fixes app crash in release apk caused by proguard-rules (closes #9).